### PR TITLE
Issue #8 - allow format for axis label to be passed in.

### DIFF
--- a/ascii-render/src/main/java/com/indvd00m/ascii/render/elements/plot/AxisLabels.java
+++ b/ascii-render/src/main/java/com/indvd00m/ascii/render/elements/plot/AxisLabels.java
@@ -27,9 +27,16 @@ public class AxisLabels extends AbstractPlotObject<AxisLabels> {
 	protected int countY = 5;
 	protected List<AxisLabel> labels = new ArrayList<AxisLabel>();
 	protected int labelsYWidth;
+	protected String labelsFormat = "%1$,.2f";
 
 	public AxisLabels(List<IPlotPoint> points, IRegion region) {
 		super(points, region);
+		generateLabels();
+	}
+
+	public AxisLabels(List<IPlotPoint> points, IRegion region, String labelFormat) {
+		super(points, region);
+		this.labelsFormat = labelFormat;
 		generateLabels();
 	}
 
@@ -37,6 +44,14 @@ public class AxisLabels extends AbstractPlotObject<AxisLabels> {
 		super(points, region);
 		this.countX = countX;
 		this.countY = countY;
+		generateLabels();
+	}
+	
+	public AxisLabels(List<IPlotPoint> points, IRegion region, int countX, int countY, String labelFormat) {
+		super(points, region);
+		this.countX = countX;
+		this.countY = countY;
+		this.labelsFormat = labelFormat;
 		generateLabels();
 	}
 
@@ -128,7 +143,7 @@ public class AxisLabels extends AbstractPlotObject<AxisLabels> {
 	protected String format(AxisType type, double value, double labelsStep) {
 		String label = null;
 		if (labelsStep < 10d) {
-			label = String.format("%1$,.2f", value);
+			label = String.format(labelsFormat, value);
 		} else {
 			label = String.format("%,d", (int) value);
 		}
@@ -177,5 +192,4 @@ public class AxisLabels extends AbstractPlotObject<AxisLabels> {
 	public int getLabelsYWidth() {
 		return labelsYWidth;
 	}
-
 }


### PR DESCRIPTION
On issue #8 (now closed), I've been writing code like this to adjust the format of axis labels:

```
		builder.element(new AxisLabels(overallErrPoints, new Region(0, 0, 78, 18)) {
			@Override
			public String format(AxisType type, double value, double labelsStep) {
				String label = null;
				if (labelsStep < 10d) {
					label = String.format("%1$,.4f", value);
				} else {
					label = String.format("%,d", (int) value);
				}
				return label;
			}
		});
```

To tidy up, here is a pull request to allow the format string to be passed in on the AxisType constructor.  This reduces the necessary code to a single line:

```
builder.element(new AxisLabels(overallErrPoints, new Region(0, 0, 78, 18),"%1$,.4f"));
```