### PR TITLE
Add module infos

### DIFF
--- a/ascii-render-api/pom.xml
+++ b/ascii-render-api/pom.xml
@@ -146,6 +146,31 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.moditect</groupId>
+				<artifactId>moditect-maven-plugin</artifactId>
+				<version>1.0.0.Final</version>
+				<executions>
+					<execution>
+						<id>add-module-infos</id>
+						<phase>package</phase>
+						<goals>
+							<goal>add-module-info</goal>
+						</goals>
+						<configuration>
+							<jvmVersion>9</jvmVersion>
+							<module>
+								<moduleInfo>
+									<name>com.indvd00m.ascii.render.api</name>
+									<exports>
+										*;
+									</exports>
+								</moduleInfo>
+							</module>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/ascii-render/pom.xml
+++ b/ascii-render/pom.xml
@@ -161,6 +161,31 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.moditect</groupId>
+				<artifactId>moditect-maven-plugin</artifactId>
+				<version>1.0.0.Final</version>
+				<executions>
+					<execution>
+						<id>add-module-infos</id>
+						<phase>package</phase>
+						<goals>
+							<goal>add-module-info</goal>
+						</goals>
+						<configuration>
+							<jvmVersion>9</jvmVersion>
+							<module>
+								<moduleInfo>
+									<name>com.indvd00m.ascii.render</name>
+									<exports>
+										*;
+									</exports>
+								</moduleInfo>
+							</module>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Adds `module-info` for Java 9+ consumers